### PR TITLE
add links for active groups, mark others as inactive

### DIFF
--- a/source/working-groups.md
+++ b/source/working-groups.md
@@ -10,7 +10,7 @@
 - [Sensitive Data](https://groups.google.com/g/dataverse-community/c/P-yR0JV26Fc/m/l11RQ4cwAQAJ)
 
 ## Working Groups (WG)
-- Big Data (inactive)
+- [Big Data](https://dataversecommunity.slack.com/archives/C06429RS3D5)
 - [Containerization](https://ct.gdcc.io)
 - Controlled Vocabularies (inactive)
 - Dataverse Sustainability ([charter](https://docs.google.com/document/d/17zp7hBy4OeprpZ4cL2YwuhpRL9li-7j_OCjYE0MYC1k/edit?usp=sharing))

--- a/source/working-groups.md
+++ b/source/working-groups.md
@@ -1,18 +1,19 @@
 # Working Groups
 ## Interest Groups (IG)
-- Computational Workflows
-- Data Documentation Initiative (DDI)
-- DevOps
-- Geospatial Data
-- Linked Data Notifications (LDN)
-- Metadata
-- pyDataverse
-- Sensitive Data
+- Computational Workflows (inactive)
+- Data Documentation Initiative (DDI) (inactive)
+- DevOps (inactive)
+- Geospatial Data (inactive)
+- Linked Data Notifications (LDN) (inactive)
+- Metadata (inactive)
+- pyDataverse (inactive)
+- [Sensitive Data](https://groups.google.com/g/dataverse-community/c/P-yR0JV26Fc/m/l11RQ4cwAQAJ)
 
 ## Working Groups (WG)
-- Big Data
-- Controlled Vocabularies
+- Big Data (inactive)
+- [Containerization](https://ct.gdcc.io)
+- Controlled Vocabularies (inactive)
 - Dataverse Sustainability ([charter](https://docs.google.com/document/d/17zp7hBy4OeprpZ4cL2YwuhpRL9li-7j_OCjYE0MYC1k/edit?usp=sharing))
-- Registry Metadata
-- Software Metadata
-- UI Components
+- Registry Metadata (inactive)
+- Software Metadata (inactive)
+- [UI Component Library](https://groups.google.com/g/dataverse-community/c/4iuH6HRUy2c/m/59beyU3OAQAJ)


### PR DESCRIPTION
Here's a preview:

![Screenshot 2023-12-12 at 9 35 07 AM](https://github.com/gdcc/dataversecommunity.global/assets/21006/cc078fb2-8832-4abc-8961-3c49e816b5dc)

Of the four active working groups, I believe only the container group has a website. The other groups should probably work on having something better to link to (I linked to what I could).

I wrote "inactive" next to the rest of the groups but we could also just delete them? Or group them together under and "inactive" heading at the bottom?